### PR TITLE
Update rgb_options.ini base on Adafruit doc

### DIFF
--- a/config/rgb_options.ini
+++ b/config/rgb_options.ini
@@ -3,10 +3,9 @@ rows = 64
 columns = 64
 chain_length = 1
 parallel = 1
-hardware_mapping = adafruit-hat-pwm
+hardware_mapping = adafruit-hat
 gpio_slowdown = 2
 brightness = 70
 default_image = ../images/default.png
 power = on
 refresh_rate = 60
-


### PR DESCRIPTION
Suggestion to update the RGB Options based on https://github.com/hzeller/rpi-rgb-led-matrix/tree/master/bindings/python

## Summary
Hardware: Raspberry PI W + Adafruit RGB Matrix Bonnet 
Followed the readme instruction but the display  wasn't showing anythink than after check the adafruit tutorial  ran successfully the C++ and Python samples too.  
The solution on my case was to update the hardware_mapping to `adafruit-hat` than the display start to show the audio cover image